### PR TITLE
Introduce changes from WHMCS 7.0 to module

### DIFF
--- a/lib/Plesk/Manager/V1000.php
+++ b/lib/Plesk/Manager/V1000.php
@@ -2,6 +2,7 @@
 // Copyright 1999-2016. Parallels IP Holdings GmbH.
 
 use Illuminate\Database\Capsule\Manager as Capsule;
+use WHMCS\Input\Sanitize;
 
 class Plesk_Manager_V1000 extends Plesk_Manager_Base
 {
@@ -132,10 +133,10 @@ class Plesk_Manager_V1000 extends Plesk_Manager_Base
                 '<input type="submit" class="button" value="%s" />' .
                 '</form>',
                 $secure,
-                WHMCS\Input\Sanitize::encode($domain),
-                WHMCS\Input\Sanitize::encode($port),
-                WHMCS\Input\Sanitize::encode($ownerInfo['login']),
-                WHMCS\Input\Sanitize::encode(decrypt($hosting->password)),
+                Sanitize::encode($domain),
+                Sanitize::encode($port),
+                Sanitize::encode($ownerInfo['login']),
+                Sanitize::encode(decrypt($hosting->password)),
                 Plesk_Registry::getInstance()->translator->translate('BUTTON_CONTROL_PANEL')
             );
         }

--- a/lib/Plesk/Manager/V1000.php
+++ b/lib/Plesk/Manager/V1000.php
@@ -486,4 +486,13 @@ class Plesk_Manager_V1000 extends Plesk_Manager_Base
             );
         }
     }
+
+    /**
+     * @return array
+     */
+    protected function _getServicePlans()
+    {
+        return array();
+    }
+
 }

--- a/lib/Plesk/Manager/V1630.php
+++ b/lib/Plesk/Manager/V1630.php
@@ -471,4 +471,14 @@ class Plesk_Manager_V1630 extends Plesk_Manager_V1000
         }
         return $result;
     }
+
+    protected function _getServicePlans()
+    {
+        $result = Plesk_Registry::getInstance()->api->service_plan_get();
+        $plans = array();
+        foreach ($result->xpath('//service-plan/get/result') as $plan) {
+            $plans[] = (string) $plan->name;
+        }
+        return $plans;
+    }
 }

--- a/lib/Plesk/Manager/V1635.php
+++ b/lib/Plesk/Manager/V1635.php
@@ -1,6 +1,8 @@
 <?php
 // Copyright 1999-2016. Parallels IP Holdings GmbH.
 
+use WHMCS\Input\Sanitize;
+
 class Plesk_Manager_V1635 extends Plesk_Manager_V1632
 {
     protected function _createSession($params)
@@ -40,10 +42,10 @@ class Plesk_Manager_V1635 extends Plesk_Manager_V1632
             '<input type="submit" value="%s" />' .
             '</form>',
             $secure,
-            WHMCS\Input\Sanitize::encode($address),
-            WHMCS\Input\Sanitize::encode($port),
-            WHMCS\Input\Sanitize::encode($sessionId),
-            WHMCS\Input\Sanitize::encode($sessionId),
+            Sanitize::encode($address),
+            Sanitize::encode($port),
+            Sanitize::encode($sessionId),
+            Sanitize::encode($sessionId),
             Plesk_Registry::getInstance()->translator->translate('BUTTON_CONTROL_PANEL')
         );
 

--- a/plesk.php
+++ b/plesk.php
@@ -4,32 +4,62 @@
 require_once 'lib/Plesk/Loader.php';
 
 use Illuminate\Database\Capsule\Manager as Capsule;
+use WHMCS\Input\Sanitize;
 
 function plesk_MetaData() {
     return array(
-        'DisplayName' => 'Plesk V8+',
+        'DisplayName' => 'Plesk',
         'APIVersion' => '1.1',
     );
 }
 
 /**
+ * @param array $params
  * @return array
  */
-function plesk_ConfigOptions($params)
+function plesk_ConfigOptions(array $params)
 {
     require_once 'lib/Plesk/Translate.php';
     $translator = new Plesk_Translate();
+
+    $resellerSimpleMode = ($params['producttype'] == 'reselleraccount');
 
     $configarray = array(
         "servicePlanName" => array(
             "FriendlyName" => $translator->translate("CONFIG_SERVICE_PLAN_NAME"),
             "Type" => "text",
-            "Size" => "25"
+            "Size" => "25",
+            'Loader' => function(array $params) {
+                $return = array();
+
+                Plesk_Loader::init($params);
+                $packages = Plesk_Registry::getInstance()->manager->getServicePlans();
+                $return[''] = 'None';
+                foreach ($packages as $package) {
+                    $return[$package] = $package;
+                }
+
+                return $return;
+            },
+            'SimpleMode' => true,
         ),
         "resellerPlanName" => array(
             "FriendlyName" => $translator->translate("CONFIG_RESELLER_PLAN_NAME"),
             "Type" => "text",
-            "Size" => "25"
+            "Size" => "25",
+            'Loader' => function(array $params) {
+                $return = array();
+
+                Plesk_Loader::init($params);
+                $packages = Plesk_Registry::getInstance()->manager->getResellerPlans();
+                $return[''] = 'None';
+                foreach ($packages as $package) {
+                    $return[$package] = $package;
+                }
+
+                return $return;
+            },
+            'SimpleMode' => $resellerSimpleMode,
         ),
         "ipAdresses" => array (
             "FriendlyName" => $translator->translate("CONFIG_WHICH_IP_ADDRESSES"),
@@ -37,6 +67,7 @@ function plesk_ConfigOptions($params)
             "Options" => "IPv4 shared; IPv6 none,IPv4 dedicated; IPv6 none,IPv4 none; IPv6 shared,IPv4 none; IPv6 dedicated,IPv4 shared; IPv6 shared,IPv4 shared; IPv6 dedicated,IPv4 dedicated; IPv6 shared,IPv4 dedicated; IPv6 dedicated",
             "Default" => "IPv4 shared; IPv6 none",
             "Description" => "",
+            'SimpleMode' => true,
         ),
         "powerUser" => array(
             "FriendlyName" => $translator->translate("CONFIG_POWER_USER_MODE"),
@@ -69,10 +100,10 @@ function plesk_AdminLink($params)
         '<input type="submit" value="%s">' .
         '</form>',
         $secure,
-        WHMCS\Input\Sanitize::encode($address),
-        WHMCS\Input\Sanitize::encode($port),
-        WHMCS\Input\Sanitize::encode($params["serverusername"]),
-        WHMCS\Input\Sanitize::encode($params["serverpassword"]),
+        Sanitize::encode($address),
+        Sanitize::encode($port),
+        Sanitize::encode($params["serverusername"]),
+        Sanitize::encode($params["serverpassword"]),
         'Login to panel'
     );
 

--- a/templates/api/1.6.3.0/service_plan_get.tpl
+++ b/templates/api/1.6.3.0/service_plan_get.tpl
@@ -1,0 +1,5 @@
+<service-plan>
+    <get>
+        <filter/>
+    </get>
+</service-plan>


### PR DESCRIPTION
CORE-10577

This commit introduces some of the changes to the plesk
module WHMCS developed as part of their feature work in the 7.0
series. The biggest change comes from the introduction of simple
mode configuration. To aid this we implemented a new API function
and this including the matching API template. It also contains
some hygiene fixes: adding use statements, migrating from full class
names to the short names based on use statements for input sanitization
which set you up for namespace support, and a few parameter tags and
checks, which allow the IDE to do better static analysis.

Merging this commit to the master branch ensures that the code in
your repo is the same as the code in the WHMCS mainline branch and
should reduce the effort necessary to pull in changes in future
releases.