### PR TITLE
Usage updating for Reseller plans

### DIFF
--- a/lib/Plesk/Manager/V1630.php
+++ b/lib/Plesk/Manager/V1630.php
@@ -415,7 +415,7 @@ class Plesk_Manager_V1630 extends Plesk_Manager_V1000
      * @return array (<domainName> => array ('diskusage' => value, 'disklimit' => value, 'bwusage' => value, 'bwlimit' => value))
      * @throws Exception
      */
-    protected function _getResellerUsage($params)
+    protected function _getResellersUsage($params)
     {  
         $usage = array();
         $data = Plesk_Registry::getInstance()->api->reseller_usage_get_by_login(array('logins' => $params['usernames']));

--- a/lib/Plesk/Manager/V1630.php
+++ b/lib/Plesk/Manager/V1630.php
@@ -412,18 +412,18 @@ class Plesk_Manager_V1630 extends Plesk_Manager_V1000
     
     /**
      * @param $params
-     * @return array (<domainName> => array ('diskusage' => value, 'disklimit' => value, 'bwusage' => value, 'bwlimit' => value))
+     * @return array (<username> => array ('diskusage' => value, 'disklimit' => value, 'bwusage' => value, 'bwlimit' => value))
      * @throws Exception
      */
     protected function _getResellersUsage($params)
     {  
         $usage = array();
-        $data = Plesk_Registry::getInstance()->api->reseller_usage_get_by_login(array('logins' => $params['usernames']));
+        $data = Plesk_Registry::getInstance()->api->reseller_get_usage_by_login(array('logins' => $params['usernames']));
         foreach($data->xpath('//reseller/get/result') as $result) {
             try {
                 $this->_checkErrors($result);
-                $login = (string)$result->data->gen_info->login;
-                $usage[$login]['diskusage'] = (float)$result->data->gen_info->real_size;
+                $login = (string)$result->data->{'gen-info'}->login;
+                $usage[$login]['diskusage'] = (float)$result->data->stat->{'disk-space'};
                 $usage[$login]['bwusage'] = (float)$result->data->stat->traffic;
                 $usage[$login] = array_merge($usage[$login], $this->_getLimits($result->data->limits));
             } catch (Exception $e) {

--- a/plesk.php
+++ b/plesk.php
@@ -378,59 +378,63 @@ function plesk_UsageUpdate($params) {
         if ($hosting->type === 'reselleraccount'){
             $reseller_usernames[] = $hosting->username;
         }
-        else{
+        else if (!empty($hosting->domain)){
             $domains[] = $hosting->domain;
         }
     }
     
     /** Reseller Plan Updates **/
-    $params["usernames"] = $reseller_usernames;
-    try {
-        Plesk_Loader::init($params);
-        $resellerAccountsUsage = Plesk_Registry::getInstance()->manager->getResellersUsage($params);
-    } catch (Exception $e) {
-        return Plesk_Registry::getInstance()->translator->translate('ERROR_COMMON_MESSAGE', array('CODE' => $e->getCode(), 'MESSAGE' => $e->getMessage()));
-    }
-    
-    foreach ( $resellerAccountsUsage as $username => $usage ) {
+    if (!empty($reseller_usernames)){
+      $params["usernames"] = $reseller_usernames;
+      try {
+          Plesk_Loader::init($params);
+          $resellerAccountsUsage = Plesk_Registry::getInstance()->manager->getResellersUsage($params);
+      } catch (Exception $e) {
+          return Plesk_Registry::getInstance()->translator->translate('ERROR_COMMON_MESSAGE', array('CODE' => $e->getCode(), 'MESSAGE' => $e->getMessage()));
+      }
 
-        Capsule::table('tblhosting')
-            ->where('server', $params["serverid"])
-            ->where('username', $username)
-            ->update(
-                array(
-                    "diskusage" => $usage['diskusage'],
-                    "disklimit" => $usage['disklimit'],
-                    "bwusage" => $usage['bwusage'],
-                    "bwlimit" => $usage['bwlimit'],
-                    "lastupdate" => Capsule::table('tblhosting')->raw('now()'),
-                )
-            );
-    }
-    
-    /** Standard hosting plan updates **/
-    $params["domains"] = $domains;
-    try {
-        Plesk_Loader::init($params);
-        $domainsUsage = Plesk_Registry::getInstance()->manager->getWebspacesUsage($params);
-    } catch (Exception $e) {
-        return Plesk_Registry::getInstance()->translator->translate('ERROR_COMMON_MESSAGE', array('CODE' => $e->getCode(), 'MESSAGE' => $e->getMessage()));
-    }
-    
-    foreach ( $domainsUsage as $domainName => $usage ) {
+      foreach ( $resellerAccountsUsage as $username => $usage ) {
 
-        Capsule::table('tblhosting')
-            ->where('server', $params["serverid"])
-            ->where('domain', $domainName)
-            ->update(
-                array(
-                    "diskusage" => $usage['diskusage'],
-                    "disklimit" => $usage['disklimit'],
-                    "bwusage" => $usage['bwusage'],
-                    "bwlimit" => $usage['bwlimit'],
-                    "lastupdate" => Capsule::table('tblhosting')->raw('now()'),
-                )
-            );
+          Capsule::table('tblhosting')
+              ->where('server', $params["serverid"])
+              ->where('username', $username)
+              ->update(
+                  array(
+                      "diskusage" => $usage['diskusage'],
+                      "disklimit" => $usage['disklimit'],
+                      "bwusage" => $usage['bwusage'],
+                      "bwlimit" => $usage['bwlimit'],
+                      "lastupdate" => Capsule::table('tblhosting')->raw('now()'),
+                  )
+              );
+      }
+    }
+    
+    if (!empty($domains)){
+      /** Standard hosting plan updates **/
+      $params["domains"] = $domains;
+      try {
+          Plesk_Loader::init($params);
+          $domainsUsage = Plesk_Registry::getInstance()->manager->getWebspacesUsage($params);
+      } catch (Exception $e) {
+          return Plesk_Registry::getInstance()->translator->translate('ERROR_COMMON_MESSAGE', array('CODE' => $e->getCode(), 'MESSAGE' => $e->getMessage()));
+      }
+      
+      foreach ( $domainsUsage as $domainName => $usage ) {
+
+          Capsule::table('tblhosting')
+              ->where('server', $params["serverid"])
+              ->where('domain', $domainName)
+              ->update(
+                  array(
+                      "diskusage" => $usage['diskusage'],
+                      "disklimit" => $usage['disklimit'],
+                      "bwusage" => $usage['bwusage'],
+                      "bwlimit" => $usage['bwlimit'],
+                      "lastupdate" => Capsule::table('tblhosting')->raw('now()'),
+                  )
+              );
+      }
     }
 
     return 'success';

--- a/plesk.php
+++ b/plesk.php
@@ -367,7 +367,8 @@ function plesk_ChangePackage($params) {
 function plesk_UsageUpdate($params) {
 
     $query = Capsule::table('tblhosting')
-        ->where('server', $params["serverid"]);
+        ->where('server', $params["serverid"])
+        ->where('domainstatus', 'Active');
 
     $domains = array();
     /** @var stdClass $hosting */

--- a/templates/api/1.6.3.0/reseller_get_usage_by_login.tpl
+++ b/templates/api/1.6.3.0/reseller_get_usage_by_login.tpl
@@ -7,9 +7,9 @@
             <?php endforeach; ?>
         </filter>
         <dataset>
-            <limits/>
+            <gen-info/>
             <stat/>
-            <gen_info/>
+            <limits/>
         </dataset>
     </get>
 </reseller>

--- a/templates/api/1.6.3.0/reseller_usage_get_by_login.tpl
+++ b/templates/api/1.6.3.0/reseller_usage_get_by_login.tpl
@@ -1,0 +1,15 @@
+<!-- Copyright 1999-2016. Parallels IP Holdings GmbH. -->
+<reseller>
+    <get>
+        <filter>
+            <?php foreach($logins as $login): ?>
+            <login><?php echo $login; ?></login>
+            <?php endforeach; ?>
+        </filter>
+        <dataset>
+            <limits/>
+            <stat/>
+            <gen_info/>
+        </dataset>
+    </get>
+</reseller>


### PR DESCRIPTION
Introduces new code to handle reseller plan usage stats updating.

Also introduces some code to ensure
regular accounts always get their stats updated successfully:

There were previously issues where a domain name being missing from
WHMCS would cause errors in Plesk API get requests.