### PR TITLE
Min password requirements

### DIFF
--- a/plesk.php
+++ b/plesk.php
@@ -135,10 +135,10 @@ function plesk_CreateAccount($params) {
   
     if ( strlen($params['password']) <= NEW_PASSWORD_LENGTH ){
       
-      $newPassword = randomPassword(NEW_PASSWORD_LENGTH);
+      $newPassword = pleskRandomPassword(NEW_PASSWORD_LENGTH);
       
       //Change password saved in WHMCS for product
-      $values["serviceid"] = $vars['params']['serviceid'];
+      $values["serviceid"] = $params['serviceid'];
       $values["servicepassword"] = $newPassword;
       $results = localAPI("updateclientproduct",$values);
       
@@ -475,7 +475,7 @@ function plesk_TestConnection($params) {
  * Limitations: only works with PHP7+ due to random_int() being used.
  */
 
-function randomPassword($size = 8) {
+function pleskRandomPassword($size = 8) {
 
     $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^*?_~';
 		$symbols = '!@#$%^*?_~';


### PR DESCRIPTION
I'll admit this may not be the *best* solution to this problem but until WHMCS itself allows for stronger passwords, this at least solves the problem for Plesk.

I would have preferred to do an API call and find out what the server's Password Strength policy is prior to changing the password (ie: only set a strong password when the server policy is set to "Very Strong") however there appears to be no way to get password strength value via XML API.

It solves these two WHMCS feature requests, but only for the Plesk module: https://requests.whmcs.com/topic/strong-password-for-newly-created-accounts-using-module
https://requests.whmcs.com/topic/increase-auto-generated-password-strenght