### PR TITLE
Fixed: IP-Assigning when user is not "admin"

### DIFF
--- a/lib/Plesk/Api.php
+++ b/lib/Plesk/Api.php
@@ -37,11 +37,6 @@ class Plesk_Api
         return $this->request($name, $params);
     }
 
-    public function isAdmin()
-    {
-        return ('admin' === $this->_login);
-    }
-
     protected function request($command, $params)
     {
         $translator = Plesk_Registry::getInstance()->translator;

--- a/lib/Plesk/Manager/V1000.php
+++ b/lib/Plesk/Manager/V1000.php
@@ -383,7 +383,6 @@ class Plesk_Manager_V1000 extends Plesk_Manager_Base
             }
         }
 
-        if (Plesk_Registry::getInstance()->api->isAdmin()) {
             switch($params["configoption3"]) {
                 case 'IPv4 shared; IPv6 none':
                     $ip['ipv4Address'] = ($params['addAddonDedicatedIPv4'])
@@ -425,10 +424,10 @@ class Plesk_Manager_V1000 extends Plesk_Manager_Base
                     $ip['ipv4Address'] = Plesk_Registry::getInstance()->manager->getFreeDedicatedIpv4();
                     $ip['ipv6Address'] = Plesk_Registry::getInstance()->manager->getFreeDedicatedIpv6();
                     break;
+				default:
+					$ip['ipv4Address'] = $params['serverip'];
+					break;
             }
-        } else {
-            $ip['ipv4Address'] = $params['serverip'];
-        }
 
         return $ip;
     }


### PR DESCRIPTION
Removed (IMHO) unnecessary function isAdmin() and the use of it when assigning IP-Addresses which would only work it the username for connecting to Plesk from WHMCS was "admin"