### PR TITLE
Make panelexternalid the primary key

### DIFF
--- a/lib/Plesk/Manager/Base.php
+++ b/lib/Plesk/Manager/Base.php
@@ -51,9 +51,8 @@ abstract class Plesk_Manager_Base
                 $table->string('usertype');
                 $table->string('panelexternalid');
 
-                $table->primary('userid');
                 $table->index('usertype');
-                $table->unique('panelexternalid');
+                $table->primary('panelexternalid');
             }
         );
     }


### PR DESCRIPTION
This is because the clientid may not be unique if the client has multiple Plesk accounts. It's actually quite common when you have multiple servers or even if the client has a shared account and a reseller account on the same server. The only truly unique element in this table is panelexternalid so it may as well be the primary key, no?

Fixes Issue #18 BUT will only fix it upon initial install...existing users of the plesk module will need to modify the table manually.