### PR TITLE
BUGFIX EXTWHMCS-47 Problem in auto-creation

### DIFF
--- a/lib/Plesk/Manager/Base.php
+++ b/lib/Plesk/Manager/Base.php
@@ -48,12 +48,11 @@ abstract class Plesk_Manager_Base
 
                 /** @var \Illuminate\Database\Schema\Blueprint $table */
                 $table->integer('userid');
-                $table->string('usertype');
-                $table->string('panelexternalid');
+                $table->string('usertype', 20);
+                $table->string('panelexternalid', 50);
 
-                $table->primary('userid');
-                $table->index('usertype');
-                $table->unique('panelexternalid');
+                $table->primary(array('panelexternalid', 'usertype'));
+                $table->index(array('userid', 'usertype'));
             }
         );
     }


### PR DESCRIPTION
@jas8522 This will be correct fix of hosting/reseller accounts issue for a one client.
The unique part is panelExternalId + usertype, because we can have a one reseller and one customer account for user with a same id. Such user has uuid in whmcs `tblclients` table and two rows in mod_pleskaccounts, like the following rows:

user_id 47
usertype hostingaccount
panelexternalid 32248f2c-4a55-41f8-b0a8-e3cbeb85b959               

and 

user_id 47
usertype reselleaccount
panelexternalid 32248f2c-4a55-41f8-b0a8-e3cbeb85b959

Seems like this will works for every our cases. So i will reject this request
https://github.com/plesk/whmcs-plugin/pull/31            
