### PR TITLE
Implement SSL Install Support for Plesk 17.8+ CORE-12440

### DIFF
--- a/lib/Plesk/Manager/V1670.php
+++ b/lib/Plesk/Manager/V1670.php
@@ -1,0 +1,25 @@
+<?php
+// Copyright 1999-2016. Parallels IP Holdings GmbH.
+// @codingStandardsIgnoreLine
+class Plesk_Manager_V1670 extends Plesk_Manager_V1660
+{
+    /**
+     * @param $params
+     * @return string
+     */
+    // @codingStandardsIgnoreLine
+    protected function _generateCSR($params)
+    {
+        return parent::_generateCSR($params);
+    }
+
+    /**
+     * @param $params
+     * @return string
+     */
+    // @codingStandardsIgnoreLine
+    protected function _installSsl($params)
+    {
+        return parent::_installSsl($params);
+    }
+}

--- a/templates/api/1.6.7.0/certificate_generate.tpl
+++ b/templates/api/1.6.7.0/certificate_generate.tpl
@@ -1,0 +1,13 @@
+<certificate>
+    <generate>
+        <info>
+            <bits>2048</bits>
+            <country><?php echo $params['country']; ?></country>
+            <state><?php echo $params['state']; ?></state>
+            <location><?php echo $params['city']; ?></location>
+            <company><?php echo $params['orgname']; ?></company>
+            <email><?php echo $params['email']; ?></email>
+            <name><?php echo $params['domain']; ?></name>
+        </info>
+    </generate>
+</certificate>

--- a/templates/api/1.6.7.0/certificate_install.tpl
+++ b/templates/api/1.6.7.0/certificate_install.tpl
@@ -1,0 +1,11 @@
+<certificate>
+    <install>
+        <name><?php echo $params['certificateDomain']; ?></name>
+        <webspace><?php echo $params['domain']; ?></webspace>
+        <content>
+            <csr><?php echo $params['csr']; ?></csr>
+            <pvt><?php echo $params['key']; ?></pvt>
+            <cert><?php echo $params['certificate']; ?></cert>
+        </content>
+    </install>
+</certificate>

--- a/templates/api/1.6.7.0/customer_get_by_external_id.tpl
+++ b/templates/api/1.6.7.0/customer_get_by_external_id.tpl
@@ -1,0 +1,11 @@
+<!-- Copyright 1999-2016. Parallels IP Holdings GmbH. -->
+<customer>
+    <get>
+        <filter>
+            <external-id><?php echo $externalId; ?></external-id>
+        </filter>
+        <dataset>
+            <gen_info/>
+        </dataset>
+    </get>
+</customer>

--- a/templates/api/1.6.7.0/customer_get_by_login.tpl
+++ b/templates/api/1.6.7.0/customer_get_by_login.tpl
@@ -1,0 +1,11 @@
+<!-- Copyright 1999-2016. Parallels IP Holdings GmbH. -->
+<customer>
+    <get>
+        <filter>
+            <login><?php echo $login; ?></login>
+        </filter>
+        <dataset>
+            <gen_info/>
+        </dataset>
+    </get>
+</customer>

--- a/templates/api/1.6.7.0/reseller_get_by_external_id.tpl
+++ b/templates/api/1.6.7.0/reseller_get_by_external_id.tpl
@@ -1,0 +1,11 @@
+<!-- Copyright 1999-2016. Parallels IP Holdings GmbH. -->
+<reseller>
+    <get>
+        <filter>
+            <external-id><?php echo $externalId; ?></external-id>
+        </filter>
+        <dataset>
+            <gen-info/>
+        </dataset>
+    </get>
+</reseller>

--- a/templates/api/1.6.7.0/reseller_get_by_login.tpl
+++ b/templates/api/1.6.7.0/reseller_get_by_login.tpl
@@ -1,0 +1,11 @@
+<!-- Copyright 1999-2016. Parallels IP Holdings GmbH. -->
+<reseller>
+    <get>
+        <filter>
+            <login><?php echo $login; ?></login>
+        </filter>
+        <dataset>
+            <gen-info/>
+        </dataset>
+    </get>
+</reseller>


### PR DESCRIPTION
This change was manually tested and confirmed to do an end to end SSL installation by WHMCS. It has merged into the WHMCS repo and is expected to be published as part of the 7.7.0 release.