### PR TITLE
Add new addons before removing old addons

### DIFF
--- a/lib/Plesk/Manager/V1630.php
+++ b/lib/Plesk/Manager/V1630.php
@@ -381,14 +381,6 @@ class Plesk_Manager_V1630 extends Plesk_Manager_V1000
         }
 
         $addonsToAdd = array_diff($addonsFromRequest, array_values($addons));
-        foreach($addonsToRemove as $guid => $addon) {
-            Plesk_Registry::getInstance()->api->webspace_remove_subscription(
-                array(
-                    'planGuid' => $guid,
-                    'id' => $webspaceId,
-                )
-            );
-        }
         foreach($addonsToAdd as $addonName) {
             $addon = Plesk_Registry::getInstance()->api->service_plan_addon_get_by_name(array('name' => $addonName));
             foreach($addon->xpath('//service-plan-addon/get/result/guid') as $guid) {
@@ -400,6 +392,14 @@ class Plesk_Manager_V1630 extends Plesk_Manager_V1000
                 );
             }
 
+        }
+        foreach($addonsToRemove as $guid => $addon) {
+            Plesk_Registry::getInstance()->api->webspace_remove_subscription(
+                array(
+                    'planGuid' => $guid,
+                    'id' => $webspaceId,
+                )
+            );
         }
     }
 


### PR DESCRIPTION
This fixes an issue where you may be increasing from 100meg of storage to 200meg and the user is using more than the base package allows. So by adding 200 first, then taking away the 100 allows the subscription to stay in quota.